### PR TITLE
Old style exception --> new style for Python 3

### DIFF
--- a/docker/docker_lamden_api/api.py
+++ b/docker/docker_lamden_api/api.py
@@ -39,7 +39,7 @@ class WebApp(object):
             endpoint, values = adapter.match()
             method = getattr(self, 'endpoint_{}'.format(endpoint))
             return method(adapter, request, **values)
-        except HTTPException, e:
+        except HTTPException as e:
             return e
 
     url_map = Map([])


### PR DESCRIPTION
Old style exceptions are a syntax error in Python 3.

flake8 testing of https://github.com/lamden/saffron on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./docker/docker_lamden_api/api.py:42:29: E999 SyntaxError: invalid syntax
        except HTTPException, e:
                            ^
./saffron/accounts.py:26:6: F821 undefined name 'database'
	a = database.init_account(name=name, address=address)
     ^
./saffron/contracts.py:113:10: F821 undefined name 'Exepction'
			raise Exepction('unable to unlock account')
         ^
./saffron/database.py:69:16: F821 undefined name 'Account'
        return Account(name=name, address=address)
               ^
1     E999 SyntaxError: invalid syntax
3     F821 undefined name 'database'
4
```