### PR TITLE
Typo: Exepction() --> Exception() in contracts.py

### DIFF
--- a/saffron/contracts.py
+++ b/saffron/contracts.py
@@ -110,7 +110,7 @@ class Contract(Contract):
 			self.address = self.web3.eth.sendTransaction(transaction={'data' : '0x' + self.bytecode, 'from': self.defaultAccount, 'gaslimit': 30000})
 			self.instance = self.web3.eth.contract(self.address)
 		else:
-			raise Exepction('unable to unlock account')
+			raise Exception('unable to unlock account')
 		#update the deployed and address to the db and an instance for pulling and interacting with the contract again
 		return update_contract(json.dumps(self.address), self.method_identifiers, self.name)
 


### PR DESCRIPTION
flake8 testing of https://github.com/lamden/saffron on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./docker/docker_lamden_api/api.py:42:29: E999 SyntaxError: invalid syntax
        except HTTPException, e:
                            ^
./saffron/accounts.py:26:6: F821 undefined name 'database'
	a = database.init_account(name=name, address=address)
     ^
./saffron/contracts.py:113:10: F821 undefined name 'Exepction'
			raise Exepction('unable to unlock account')
         ^
./saffron/database.py:69:16: F821 undefined name 'Account'
        return Account(name=name, address=address)
               ^
1     E999 SyntaxError: invalid syntax
3     F821 undefined name 'database'
4
```